### PR TITLE
Updated to void safety for first review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+EIFGENs/
 .svn
 .accurev
 

--- a/ma_memory_change_mediator.e
+++ b/ma_memory_change_mediator.e
@@ -120,14 +120,16 @@ feature -- Command
 		local
 			l_state_1, l_state_2: MA_MEMORY_STATE
 			l_info_dlg: EV_INFORMATION_DIALOG
+			l_increased: attached like grid_data_increased
 		do
 			if grid_from_state.has_selected_row then
 				if grid_to_state.has_selected_row then
 					l_state_2 := states.i_th (grid_to_state.selected_rows.first.index)
 					l_state_1 := states.i_th (grid_from_state.selected_rows.first.index)
 					grid_util.grid_remove_and_clear_all_rows (grid_changed)
-					grid_data_increased := l_state_1.compare (l_state_2)
-					update_grid_increased_content
+					l_increased := l_state_1.compare (l_state_2)
+					grid_data_increased := l_increased
+					update_grid_increased_content (l_increased)
 				else
 					create l_info_dlg.make_with_text ("Please select a To State from the right grid.")
 					l_info_dlg.show_relative_to_window (main_window)
@@ -181,39 +183,33 @@ feature -- Command
 
 feature {NONE} -- Implemention
 
-	update_grid_increased_content
+	update_grid_increased_content( a_grid_data_increased : attached like grid_data_increased)
 			-- Show the increased objects in the bottom result grid.
-		require
-			set: attached grid_data_increased
 		local
 			l_int: INTEGER
 			l_item: EV_GRID_LABEL_ITEM
 			l_i: INTEGER
 		do
-			if attached grid_data_increased as l_grid_data_increased then
-				from
-					l_grid_data_increased.start
-				until
-					l_grid_data_increased.after
-				loop
-					if not filter.filter_class (l_grid_data_increased.item_for_iteration.text) then
-						l_i := l_i + 1
-						create l_item.make_with_text (l_grid_data_increased.item_for_iteration.text)
-						l_item.set_pixmap (icons.object_grid_class_icon)
-						grid_changed.set_item (1, l_i, l_item)
-						l_int := l_grid_data_increased.item_for_iteration.nb
-						create l_item.make_with_text (l_int.out)
-						if l_int > 0 then
-							l_item.set_foreground_color (increased_color)
-						else
-							l_item.set_foreground_color (decreased_color)
-						end
-						grid_changed.set_item (2, l_i, l_item)
+			from
+				a_grid_data_increased.start
+			until
+				a_grid_data_increased.after
+			loop
+				if not filter.filter_class (a_grid_data_increased.item_for_iteration.text) then
+					l_i := l_i + 1
+					create l_item.make_with_text (a_grid_data_increased.item_for_iteration.text)
+					l_item.set_pixmap (icons.object_grid_class_icon)
+					grid_changed.set_item (1, l_i, l_item)
+					l_int := a_grid_data_increased.item_for_iteration.nb
+					create l_item.make_with_text (l_int.out)
+					if l_int > 0 then
+						l_item.set_foreground_color (increased_color)
+					else
+						l_item.set_foreground_color (decreased_color)
 					end
-					l_grid_data_increased.forth
+					grid_changed.set_item (2, l_i, l_item)
 				end
-			else
-				check attached_grid_data_increased : false end -- Implied by precondition `set'
+				a_grid_data_increased.forth
 			end
 		end
 
@@ -274,36 +270,24 @@ feature {NONE} -- Implemention
 					sorted_column := a_column_index
 					sorting_order := False
 				end
-				if grid_data_increased /= Void then
-					sort_data
-					update_grid_increased_content
+				if attached grid_data_increased as l_grid_data_increased then
+					sort_data( l_grid_data_increased)
+					update_grid_increased_content (l_grid_data_increased)
 				end
 			end
 		end
 
-	handle_pick_item (a_item: EV_GRID_LABEL_ITEM): MA_CLASS_STONE
-			-- User pick a item from grid to filter.
-		require
-			a_item_attached : attached a_item
-			index_equal_1 : a_item.column.index = 1
-		local
-			l_result: detachable like handle_pick_item
+
+	handle_pick_item (a_item: detachable EV_GRID_ITEM): detachable MA_CLASS_STONE
+			-- User pick an item from grid to filter.
 		do
-			if a_item /= Void and a_item.column.index = 1 then
-				l_result := create {MA_CLASS_STONE}.make (a_item.text)
-			end
-			if attached l_result then
-				Result := l_result
-			else
-				check attached_l_result : false end -- Implied by preconditions
-				create Result.make ("")  --  If preonditions is not satisfied we can return whatever we want.
+			if attached {EV_GRID_LABEL_ITEM} a_item as l_label and then l_label.column.index = 1 then
+			   create {MA_CLASS_STONE} Result.make (l_label.text)
 			end
 		end
 
-	sort_data
+	sort_data (a_grid_data_increased : attached like grid_data_increased)
 			-- Sort `grid_data' according to `sorted_column' and `sorting_order'.
-		require
-			set: attached grid_data_increased
 		local
 			l_sorter: QUICK_SORTER [like grid_data_increased_row]
 			l_agent_sorter: AGENT_EQUALITY_TESTER [like grid_data_increased_row]
@@ -314,11 +298,7 @@ feature {NONE} -- Implemention
 			when 2 then create l_agent_sorter.make (agent sort_on_count)
 			end
 			create l_sorter.make (l_agent_sorter)
-			if attached grid_data_increased as l_grid_data_increased then
-				l_sorter.sort (l_grid_data_increased)
-			else
-				check attached_grid_data_increased : false end -- Implied by precondition
-			end
+			l_sorter.sort (a_grid_data_increased)
 		end
 
 	sorting_order: BOOLEAN
@@ -357,16 +337,11 @@ feature {NONE} -- Implemention
 			-- Anchor type should not called.
 			-- first INTEGER is increased object count, second INTEGER is the increased objects type id
 		require
-			False
-		local
-			l_result: detachable like grid_data_increased_row
+			not_callable : False
 		do
-			check False end -- Anchor type only
-			if attached l_result as l_r then
-				Result := l_result
-			else
-				create Result.default_create 
-			end
+			check False then end
+		ensure
+			for_typing_only : False
 		end
 
 	grid_data_increased: detachable ARRAYED_LIST [like grid_data_increased_row]
@@ -379,16 +354,11 @@ feature {NONE} -- Implemention
 			-- Type for the data inserted in grid
 			-- It is [Object Type Name, Eiffel Memory Used, C Memory Used, TypeId].
 		require
-			False
-		local
-			l_result: detachable like row_data
+			not_callable : False
 		do
-			check False end -- Anchor type only
-			if attached l_result as l_r then
-				Result := l_result
-			else
-				create Result.default_create
-			end
+			check False then end
+		ensure
+			for_typing_only : False
 		end
 
 	grid_from_state, grid_to_state: EV_GRID -- Two grid show states.

--- a/ma_memory_state.e
+++ b/ma_memory_state.e
@@ -48,13 +48,13 @@ feature -- Measurrment
 	item_found_count: INTEGER
 			-- after routine found_type, return the count of founded item
 		require
-			founded_type_not_void: founded_type /= Void
-		local
-			l_item_founded: like item_founded
+			founded_type_attached: attached founded_type
 		do
-			l_item_founded := item_founded
-			check l_item_founded /= Void end -- Implied by precondition
-			Result := l_item_founded.count_in_system
+			if attached item_founded as l_item_founded then
+				Result := l_item_founded.count_in_system
+			else
+				check attached_item_founded : false end -- Implied by precondition
+			end
 		end
 
 	memory_used_eiffel: INTEGER
@@ -167,22 +167,25 @@ feature {NONE} -- Implementation
 			l_result: detachable like state
 		do
 			check False end -- Anchor type only
-			check l_result /= void end -- Satisfy void-safe compiler
-			Result := l_result
+			if attached l_result as l_res then
+				Result := l_res
+			else
+				create Result
+			end
 		end
 
 	objects_states: ARRAYED_LIST [like state];
 			-- the count the objects, first argument is type name, second argument is the object instances count
 
 note
-	copyright:	"Copyright (c) 1984-2006, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 

--- a/ma_memory_state.e
+++ b/ma_memory_state.e
@@ -47,14 +47,12 @@ feature -- Measurrment
 
 	item_found_count: INTEGER
 			-- after routine found_type, return the count of founded item
-		require
-			founded_type_attached: attached founded_type
 		do
 			if attached item_founded as l_item_founded then
 				Result := l_item_founded.count_in_system
-			else
-				check attached_item_founded : false end -- Implied by precondition
 			end
+		ensure
+			 item_found_count_non_negative: Result >= 0
 		end
 
 	memory_used_eiffel: INTEGER
@@ -163,15 +161,12 @@ feature {NONE} -- Implementation
 
 	state: TUPLE [type_name: STRING; count_in_system: INTEGER]
 			-- [type_name_of_type, number of instances of type_name_of_type present in system]
-		local
-			l_result: detachable like state
+		require
+			not_callable : False
 		do
-			check False end -- Anchor type only
-			if attached l_result as l_res then
-				Result := l_res
-			else
-				create Result
-			end
+			check False then end
+		ensure
+			for_typing_only : False
 		end
 
 	objects_states: ARRAYED_LIST [like state];

--- a/ma_references_table.e
+++ b/ma_references_table.e
@@ -74,14 +74,17 @@ feature -- Element change
 			else
 				l_hash := relations.found_item
 			end
-			check l_hash /= Void end -- Implied by previous if clause
-			l_hash.force ([a_referee, data], a_referrer)
+			if attached l_hash as l_h then
+				l_h.force ([a_referee, data], a_referrer)
+			else
+				check attached_l_hash : false end -- Implied by previous if clause
+			end
 		end
 
 feature -- Removal
 
 	remove (a_referrer: G; a_referee: H)
-			-- Remove relation between `'a_referrer' and `a_referee'.
+			-- Remove relation between `'a_referrer' and `a_referee' if it exists a relation.
 		require
 			a_referrer_not_void: a_referrer /= Void
 			a_referee_not_void: a_referee /= Void
@@ -90,10 +93,13 @@ feature -- Removal
 		do
 			if relations.has_key (a_referee) then
 				l_hash := relations.found_item
-				check l_hash /= Void end -- Implied by `has_key'
-				l_hash.remove (a_referrer)
-				if l_hash.is_empty then
-					relations.remove (a_referee)
+				if attached l_hash as l_h then
+					l_h.remove (a_referrer)
+					if l_h.is_empty then
+						relations.remove (a_referee)
+					end
+				else
+					check attached_l_hash : false end -- Implied by `has_key'
 				end
 			end
 		end
@@ -103,14 +109,14 @@ feature {NONE} -- Implementation
 	relations: HASH_TABLE [like references_by_referee, H];
 
 note
-	copyright:	"Copyright (c) 1984-2006, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 end

--- a/ma_references_table.e
+++ b/ma_references_table.e
@@ -67,18 +67,12 @@ feature -- Element change
 		local
 			l_hash: detachable like references_by_referee
 		do
-			if not relations.has_key (a_referee) then
-				create l_hash.make (20)
-					-- Here we prevent extending pairs exsited or with equivalent key and value.
-				relations.force (l_hash, a_referee)
-			else
-				l_hash := relations.found_item
+			l_hash := relations.item (a_referee)
+			if l_hash = Void then
+			  create l_hash.make (20)
+			  relations.force (l_hash, a_referee)
 			end
-			if attached l_hash as l_h then
-				l_h.force ([a_referee, data], a_referrer)
-			else
-				check attached_l_hash : false end -- Implied by previous if clause
-			end
+			l_hash.force ([a_referee, data], a_referrer)
 		end
 
 feature -- Removal
@@ -91,15 +85,11 @@ feature -- Removal
 		local
 			l_hash: detachable like references_by_referee
 		do
-			if relations.has_key (a_referee) then
-				l_hash := relations.found_item
-				if attached l_hash as l_h then
-					l_h.remove (a_referrer)
-					if l_h.is_empty then
-						relations.remove (a_referee)
-					end
-				else
-					check attached_l_hash : false end -- Implied by `has_key'
+			l_hash := relations.item (a_referee)
+			if  l_hash /= Void then
+				l_hash.remove (a_referrer)
+				if l_hash.is_empty then
+					relations.remove (a_referee)
 				end
 			end
 		end

--- a/ma_route_to_once_searcher.e
+++ b/ma_route_to_once_searcher.e
@@ -40,8 +40,8 @@ feature -- Commands
 													%Please select a start point in Object Grid%N%
 													%and refresh again with Collecting Statics enabled.")
 				l_info_box.show
-			else
-				build
+			elseif attached reference_table as l_reference_table then
+				build (l_reference_table)
 			end
 		end
 
@@ -84,86 +84,81 @@ feature {NONE} -- Results
 			l_grid: like grid
 			l_route_stack: like route_stack
 		do
-			if attached grid then
-				l_grid := grid
-			else
+			l_grid := grid
+			if l_grid = Void then
 				create l_grid
 				grid := l_grid
 				init_grid (l_grid)
 				result_panel.extend (l_grid)
 			end
-			if attached l_grid as l_l_grid then
-				l_column := l_l_grid.column_count + 1
-				l_route_stack := route_stack
-				if attached l_route_stack as l_r then
-					l_array := l_r.linear_representation
-					l_l_grid.set_row_count_to (l_array.count.max (l_l_grid.row_count))
-					l_l_grid.set_column_count_to (l_column)
-					l_l_grid.column (l_column).set_title ("Route" + l_column.out)
-					from
-						l_array.start
-					until
-						l_array.after
-					loop
-						if not l_array.islast then
-							l_next_index := l_array [l_array.index + 1]
-						else
-							l_last := True
-						end
-						if not l_last then
-							l_reference_table := reference_table
-							if attached l_reference_table as l_ref then
-								l_tuple := l_ref.references_by_referee (l_next_index).item (l_array.item)
-							else
-								check attached_l_reference_table : false end -- Implied by precondition `set'
-							end
-							if l_tuple /= Void then
-								if attached {STRING} l_tuple.data as l_string then
-									l_field_name := l_string
-								else
-										--|FIXME: 2012/04/06 Shouldn't this be "(unknown)", instead of setting it Void? See review#7644004.
-									l_field_name := Void
-								end
-							else
-								l_field_name := once "(unknown)"
-							end
-						else
-								--|FIXME: 2012/04/06 Shouldn't this be "(unknown)", instead of setting it Void? See review#7644004.
-							l_field_name := Void
-						end
-						if l_field_name = Void then
-							l_field_name := once ""
-						else
-							l_field_name := l_field_name.twin
-							l_field_name.prepend (".")
-						end
-							-- Optimization, since we know that only the first object is once object.
-						if l_array.isfirst then
-							l_once := once "*"
-						else
-							l_once := once ""
-						end
-						l_name_table := name_table
-						if attached l_name_table as l_n then
-							l_name_table_item := l_n.item (l_array.item)
-							if attached l_name_table_item as l_name_item then
-								l_text := l_once + l_array.item.out + once ": {" + l_name_item + once "}" + l_field_name
-								create l_item.make_with_text (l_text)
-								l_item.set_tooltip (l_text)
-								l_l_grid.set_item (l_column, l_array.index, l_item)
-								l_array.forth
-							else
-								check attached_l_name_table_item : false end -- FIXME: Implied by ...?
-							end
-						else
-							check attached_l_name_table : false end -- Implied by precondition `set'
-						end
+			l_column := l_grid.column_count + 1
+			l_route_stack := route_stack
+			if attached l_route_stack as l_r then
+				l_array := l_r.linear_representation
+				l_grid.set_row_count_to (l_array.count.max (l_grid.row_count))
+				l_grid.set_column_count_to (l_column)
+				l_grid.column (l_column).set_title ("Route" + l_column.out)
+				from
+					l_array.start
+				until
+					l_array.after
+				loop
+					if not l_array.islast then
+						l_next_index := l_array [l_array.index + 1]
+					else
+						l_last := True
 					end
-				else
-					check attached_l_route_stack : false end -- Implied by precondition `set'
+					if not l_last then
+						l_reference_table := reference_table
+						if attached l_reference_table as l_ref then
+							l_tuple := l_ref.references_by_referee (l_next_index).item (l_array.item)
+						else
+							check attached_l_reference_table : false end -- Implied by precondition `set'
+						end
+						if l_tuple /= Void then
+							if attached {STRING} l_tuple.data as l_string then
+								l_field_name := l_string
+							else
+									--|FIXME: 2012/04/06 Shouldn't this be "(unknown)", instead of setting it Void? See review#7644004.
+								l_field_name := Void
+							end
+						else
+							l_field_name := once "(unknown)"
+						end
+					else
+							--|FIXME: 2012/04/06 Shouldn't this be "(unknown)", instead of setting it Void? See review#7644004.
+						l_field_name := Void
+					end
+					if l_field_name = Void then
+						l_field_name := once ""
+					else
+						l_field_name := l_field_name.twin
+						l_field_name.prepend (".")
+					end
+						-- Optimization, since we know that only the first object is once object.
+					if l_array.isfirst then
+						l_once := once "*"
+					else
+						l_once := once ""
+					end
+					l_name_table := name_table
+					if attached l_name_table as l_n then
+						l_name_table_item := l_n.item (l_array.item)
+						if attached l_name_table_item as l_name_item then
+							l_text := l_once + l_array.item.out + once ": {" + l_name_item + once "}" + l_field_name
+							create l_item.make_with_text (l_text)
+							l_item.set_tooltip (l_text)
+							l_grid.set_item (l_column, l_array.index, l_item)
+							l_array.forth
+						else
+							check attached_l_name_table_item : false end -- FIXME: Implied by ...?
+						end
+					else
+						check attached_l_name_table : false end -- Implied by precondition `set'
+					end
 				end
 			else
-				check attached_l_grid : false end -- Implied by previous if clause
+				check attached_l_route_stack : false end -- Implied by precondition `set'
 			end
 		end
 
@@ -188,31 +183,21 @@ feature {NONE} -- Results
 			-- Support Copy.
 		require
 			a_key_not_void: a_key /= Void
-			grid_set: attached grid
 		local
 			l_env: EV_ENVIRONMENT
-			l_grid: like grid
 		do
-			create l_env
-			if attached l_env.application as l_app and then l_app.ctrl_pressed then
-				inspect a_key.code
-				when {EV_KEY_CONSTANTS}.key_a then
-					l_grid := grid
-					if attached l_grid as l_g then
-						select_all_row (l_g)
-					else
-						check attached_l_grid :false end -- Implied by precondition `grid_set'
-					end
-				when {EV_KEY_CONSTANTS}.key_c then
-					l_grid := grid
-					if attached l_grid as l_g then
-						if not l_g.selected_items.is_empty then
-							copy_selected_items (l_g)
+			if attached grid as l_grid then
+				create l_env
+				if attached l_env.application as l_app and then l_app.ctrl_pressed then
+					inspect a_key.code
+					when {EV_KEY_CONSTANTS}.key_a then
+						select_all_row (l_grid)
+					when {EV_KEY_CONSTANTS}.key_c then
+						if not l_grid.selected_items.is_empty then
+							copy_selected_items (l_grid)
 						end
 					else
-						check attached_l_grid : false end -- Implied by precondition `grid_set'
 					end
-				else
 				end
 			end
 		end
@@ -328,29 +313,23 @@ feature {NONE} -- Results
 
 feature {NONE} -- Implementation
 
-	build
+	build ( a_reference_table : attached like reference_table)
 			-- Build route.
-		require
-			set: attached reference_table
 		local
-			l_reference_table: like reference_table
 			l_route_stack: like route_stack
+			l_visited_references : attached like visited_references
 		do
 			create l_route_stack.make (1000)
 			route_stack := l_route_stack
-			l_reference_table := reference_table
-			if attached l_reference_table as l_r then
-				create visited_references.make (l_r.referee_count)
-				if deep_visit_node (start_index) then
-					-- Found route
-					check
-						route_stack_not_empty: not l_route_stack.is_empty
-					end
-					fill_results
-					remove_last_link_to_once
+			create l_visited_references.make (a_reference_table.referee_count)
+			visited_references := l_visited_references
+			if deep_visit_node (start_index, a_reference_table, l_route_stack, l_visited_references) then
+				-- Found route
+				check
+					route_stack_not_empty: not l_route_stack.is_empty
 				end
-			else
-				check attached_l_reference_table : false end -- Implied by precondition `set'
+				fill_results
+				remove_last_link_to_once
 			end
 		end
 
@@ -371,70 +350,59 @@ feature {NONE} -- Implementation
 
 feature {NONE} -- Implementation
 
-	deep_visit_node (a_referee: like start_index): BOOLEAN
+	deep_visit_node (a_referee: like start_index;
+					 a_reference_table : attached like reference_table;
+					 a_route_stack  : attached like route_stack;
+					 a_visited_references  : attached like visited_references): BOOLEAN
 			-- Deep visit a node, Ture is found once object.
 		require
-			set: attached reference_table as l_reference_table and then attached l_reference_table.references_by_referee (a_referee)
-			set: attached route_stack
-			set: attached visited_references
+			set: attached a_reference_table.references_by_referee (a_referee)
 		local
 			l_visited_referrers: HASH_TABLE [TUPLE [like start_index, detachable ANY], like start_index]
 			l_referrer: like start_index
 			l_all_referrers_count: INTEGER
 		do
-			if is_visited (a_referee) then
+			if is_visited (a_referee, a_route_stack) then
 				Result := False
 			else
-				if attached route_stack as l_route_stack  then
-					l_route_stack.put (a_referee)
-					if attached reference_table as l_reference_table  then
-						if attached l_reference_table.references_by_referee (a_referee) as l_all_referrers  then
-							l_all_referrers_count := l_all_referrers.count
-							if l_all_referrers_count = 0 then
-									-- We reach the end. No referrer.
-								if is_once_object (a_referee) then
-									Result := True
-								else
-									Result := False
-								end
-							elseif is_once_object (a_referee) then
-								Result := True
-							else
-								if attached visited_references as l_visited_references  then
-									l_visited_referrers := l_visited_references.references_by_referee (a_referee)
-									if l_all_referrers_count = l_visited_referrers.count then
-											-- Go back one
-										Result := False
-										l_route_stack.remove
-									else
-										from
-											l_all_referrers.start
-										until
-											l_all_referrers.after or Result
-										loop
-											l_referrer := l_all_referrers.key_for_iteration
-											if not l_visited_referrers.has_key (l_referrer) then
-												l_visited_references.extend (l_referrer, a_referee, Void)
-												Result := deep_visit_node (l_referrer)
-											end
-											l_all_referrers.forth
-										end
-										if not Result then
-											l_route_stack.remove
-										end
-									end
-								else
-									check attached_l_visited_references : false end -- Implied by precondition `set'
-								end
-							end
+				a_route_stack.put (a_referee)
+				if attached a_reference_table.references_by_referee (a_referee) as l_all_referrers  then
+					l_all_referrers_count := l_all_referrers.count
+					if l_all_referrers_count = 0 then
+							-- We reach the end. No referrer.
+						if is_once_object (a_referee) then
+							Result := True
 						else
-							check attached_l_reference_table_references_by_referee : false end -- Implied by precondition `set'
+							Result := False
 						end
+					elseif is_once_object (a_referee) then
+						Result := True
 					else
-						check attached_l_reference_table : false end -- Implied by precondition `set'
+						l_visited_referrers := a_visited_references.references_by_referee (a_referee)
+						if l_all_referrers_count = l_visited_referrers.count then
+								-- Go back one
+							Result := False
+							a_route_stack.remove
+						else
+							from
+								l_all_referrers.start
+							until
+								l_all_referrers.after or Result
+							loop
+								l_referrer := l_all_referrers.key_for_iteration
+								if not l_visited_referrers.has_key (l_referrer) then
+									a_visited_references.extend (l_referrer, a_referee, Void)
+									Result := deep_visit_node (l_referrer, a_reference_table, a_route_stack, a_visited_references)
+								end
+								l_all_referrers.forth
+							end
+							if not Result then
+								a_route_stack.remove
+							end
+						end
 					end
 				else
-					check attached_l_route_stack : false end -- Implied by precondition `set'
+					check attached_l_reference_table_references_by_referee : false end -- Implied by precondition `set'
 				end
 			end
 		end
@@ -460,27 +428,17 @@ feature {NONE} -- Implementation
 			end
 		end
 
-	is_visited (a_node: like start_index): BOOLEAN
+	is_visited (a_node: like start_index; a_route_stack : attached like route_stack): BOOLEAN
 			-- Is `a_node' visited?
-		require
-			set: attached route_stack
 		do
-			if attached route_stack as l_route_stack then
-				Result := l_route_stack.has (a_node)
-			else
-				check attached_route_stack : false end -- Implied by precondition `set'					
-			end
+			Result := a_route_stack.has (a_node)
 		end
 
 	is_once_object (a_object: like start_index): BOOLEAN
 			-- Is `a_object' once?
-		require
-			set: attached once_objects_table
 		do
 			if attached once_objects_table as l_table  then
 				Result := l_table.has (a_object)
-			else
-				check attached_l_table : false end -- Implied by precondition `set'
 			end
 		end
 

--- a/memory_analyzer-safe.ecf
+++ b/memory_analyzer-safe.ecf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-10-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-10-0 http://www.eiffel.com/developers/xml/configuration-1-10-0.xsd" name="memory_analyzer" uuid="BF699013-E4A2-4C7F-AA12-4376BEA92D93" library_target="memory_analyzer">
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-12-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-12-0 http://www.eiffel.com/developers/xml/configuration-1-12-0.xsd" name="memory_analyzer" uuid="BF699013-E4A2-4C7F-AA12-4376BEA92D93" library_target="memory_analyzer">
 	<target name="memory_analyzer">
 		<description>Memory analyzer library: Track down your memory usage within your application.
       Copyright (c) 1984-2006, Eiffel Software and others.
@@ -12,7 +12,7 @@
 		</option>
 		<library name="base" location="$ISE_LIBRARY\library\base\base-safe.ecf"/>
 		<library name="base_extension" location="$ISE_LIBRARY\library\base_extension\base_extension-safe.ecf"/>
-		<library name="graph" location="$ISE_LIBRARY\library\graph\graph-safe.ecf"/>
+		<library name="graph" location="C:\Users\andersoxie\Documents\GitHub\EG-complete-safe\graph-safe.ecf"/>
 		<library name="time" location="$ISE_LIBRARY\library\time\time-safe.ecf"/>
 		<library name="vision2" location="$ISE_LIBRARY\library\vision2\vision2-safe.ecf"/>
 		<cluster name="memory_analyzer" location=".\"/>

--- a/memory_analyzer.ecf
+++ b/memory_analyzer.ecf
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-10-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-10-0 http://www.eiffel.com/developers/xml/configuration-1-10-0.xsd" name="memory_analyzer" uuid="BF699013-E4A2-4C7F-AA12-4376BEA92D93" library_target="memory_analyzer">
+<system xmlns="http://www.eiffel.com/developers/xml/configuration-1-12-0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.eiffel.com/developers/xml/configuration-1-12-0 http://www.eiffel.com/developers/xml/configuration-1-12-0.xsd" name="memory_analyzer" uuid="BF699013-E4A2-4C7F-AA12-4376BEA92D93" library_target="memory_analyzer">
 	<target name="memory_analyzer">
-		<description>Memory analyzer library: Track down your memory usage within your application.&#10;      Copyright (c) 1984-2006, Eiffel Software and others.&#10;      Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt).</description>
+		<description>Memory analyzer library: Track down your memory usage within your application.
+      Copyright (c) 1984-2006, Eiffel Software and others.
+      Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt).</description>
 		<root all_classes="true"/>
 		<file_rule>
 			<exclude>/\.svn</exclude>
 		</file_rule>
-		<option warning="true" is_attached_by_default="false" syntax="standard">
+		<option warning="true" full_class_checking="false" is_attached_by_default="false" void_safety="none" syntax="standard">
 		</option>
 		<library name="base" location="$ISE_LIBRARY\library\base\base.ecf"/>
 		<library name="base_extension" location="$ISE_LIBRARY\library\base_extension\base_extension.ecf"/>

--- a/object_graph/ma_figure_factory.e
+++ b/object_graph/ma_figure_factory.e
@@ -43,7 +43,7 @@ feature -- Basic operations
 				Result := l_r
 			else
 				check attached_l_result: false end -- Satisfy void-safe compiler
-				create Result -- If no precondtions or checks are switch on this statement will be executed. However, since it is not implemented according to first check statement it might be that we should remove the feature?
+				create Result
 			end
 --			node_name := node.name
 --			if node_name.is_equal ("ELLIPSE_NODE") then

--- a/object_graph/ma_figure_factory.e
+++ b/object_graph/ma_figure_factory.e
@@ -39,8 +39,12 @@ feature -- Basic operations
 			l_result: detachable like model_from_xml
 		do
 			check not_implemented: False end
-			check attached l_result end -- Satisfy void-safe compiler
-			Result := l_result
+			if attached l_result as l_r then
+				Result := l_r
+			else
+				check attached_l_result: false end -- Satisfy void-safe compiler
+				create Result -- If no precondtions or checks are switch on this statement will be executed. However, since it is not implemented according to first check statement it might be that we should remove the feature?
+			end
 --			node_name := node.name
 --			if node_name.is_equal ("ELLIPSE_NODE") then
 --				create {EG_NODE} Result
@@ -63,14 +67,14 @@ feature -- Basic operations
 		end
 
 note
-	copyright:	"Copyright (c) 1984-2006, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 

--- a/object_graph/ma_object_node.e
+++ b/object_graph/ma_object_node.e
@@ -21,9 +21,6 @@ inherit
 create
 	make_with_model
 
-create {MA_OBJECT_NODE}
-	make_filled
-
 feature {NONE} -- Initialization
 
 	default_create
@@ -60,7 +57,7 @@ feature {NONE} -- Initialization
 
 feature -- Access
 
-	model: detachable EG_NODE
+	model: EG_NODE
 			-- Model `Current' is a view for.
 
 	port_x: INTEGER
@@ -178,21 +175,21 @@ feature {NONE} -- Implementation
 	new_filled_list (n: INTEGER): like Current
 			-- New list with `n' elements.
 		do
-			create Result.make_filled (n)
+			check unimplemented: False then end
 		end
 
 invariant
 	node_figure_not_void: node_figure /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2006, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 

--- a/object_graph/ma_reference_link.e
+++ b/object_graph/ma_reference_link.e
@@ -12,14 +12,12 @@ inherit
 	EG_LINK_FIGURE
 		redefine
 			default_create,
-			xml_node_name
+			xml_node_name,
+			model
 		end
 
 create
 	make_with_model
-
-create {MA_REFERENCE_LINK}
-	make_filled
 
 feature {NONE} -- Initialization
 
@@ -39,8 +37,8 @@ feature {NONE} -- Initialization
 		require
 			a_model_not_void: a_model /= Void
 		do
-			default_create
 			model := a_model
+			default_create
 			initialize
 
 			if a_model.is_directed then
@@ -59,6 +57,10 @@ feature {NONE} -- Initialization
 		end
 
 feature -- Access
+
+	model: EG_LINK
+ 			-- <Precursor>
+ 			-- Not useful redefinition if the library rely on a graph library with `model' attached.
 
 	set_color
 			-- Set the color of the reference line.
@@ -107,46 +109,41 @@ feature {EG_FIGURE, EG_FIGURE_WORLD} -- Update
 			an_angle: DOUBLE
 			source_size: EV_RECTANGLE
 		do
-			if attached model as l_model then
-				if not l_model.is_reflexive then
-					if attached source as l_source and then attached target as l_target then
-						p1 := line.point_array.item (0)
-						p2 := line.point_array.item (1)
+			if not model.is_reflexive then
+				if attached source as l_source and then attached target as l_target then
+					p1 := line.point_array.item (0)
+					p2 := line.point_array.item (1)
 
-						p1.set (l_source.port_x, l_source.port_y)
-						p2.set (l_target.port_x, l_target.port_y)
+					p1.set (l_source.port_x, l_source.port_y)
+					p2.set (l_target.port_x, l_target.port_y)
 
-						an_angle := line_angle (p1.x_precise, p1.y_precise, p2.x_precise, p2.y_precise)
-						l_source.update_edge_point (p1, an_angle)
-						an_angle := pi + an_angle
-						l_target.update_edge_point (p2, an_angle)
-					elseif attached source as l_source_2 then
-						p1 := line.point_array.item (0)
-						p1.set (l_source_2.port_x, l_source_2.port_y)
-						l_source_2.update_edge_point (p1, 0)
-					elseif attached target as l_target_2 then
-						p2 := line.point_array.item (1)
-						p2.set (l_target_2.port_x, l_target_2.port_y)
-						l_target_2.update_edge_point (p2, 0)
-					end
+					an_angle := line_angle (p1.x_precise, p1.y_precise, p2.x_precise, p2.y_precise)
+					l_source.update_edge_point (p1, an_angle)
+					an_angle := pi + an_angle
+					l_target.update_edge_point (p2, an_angle)
+				elseif attached source as l_source_2 then
+					p1 := line.point_array.item (0)
+					p1.set (l_source_2.port_x, l_source_2.port_y)
+					l_source_2.update_edge_point (p1, 0)
+				elseif attached target as l_target_2 then
+					p2 := line.point_array.item (1)
+					p2.set (l_target_2.port_x, l_target_2.port_y)
+					l_target_2.update_edge_point (p2, 0)
+				end
 
-					line.invalidate
-					line.center_invalidate
-					if is_label_shown then
-						name_label.set_point_position (line.x, line.y)
-					end
-				else
-					if attached source as l_source_3 then
-						source_size := l_source_3.size
-						reflexive.set_x_y (source_size.right + reflexive.radius1, source_size.top + source_size.height // 2)
-					end
-					if is_label_shown then
-						name_label.set_point_position (reflexive.x + reflexive.radius1, reflexive.y)
-					end
+				line.invalidate
+				line.center_invalidate
+				if is_label_shown then
+					name_label.set_point_position (line.x, line.y)
 				end
 			else
-				check attached_model : false end -- Implied by precondition model_attached
-				-- if model is not attached the precondtion is not satisfied  and we just ignore the call to update since the behaviour is undefined.
+				if attached source as l_source_3 then
+					source_size := l_source_3.size
+					reflexive.set_x_y (source_size.right + reflexive.radius1, source_size.top + source_size.height // 2)
+				end
+				if is_label_shown then
+					name_label.set_point_position (reflexive.x + reflexive.radius1, reflexive.y)
+				end
 			end
 			is_update_required := False
 		end
@@ -168,7 +165,7 @@ feature {NONE} -- Implementation
 	on_is_directed_change
 			-- `model'.`is_directed' changed.
 		do
-			if attached model as l_model and then l_model.is_directed then
+			if model.is_directed then
 				line.enable_end_arrow
 			else
 				line.disable_end_arrow
@@ -182,11 +179,12 @@ feature {NONE} -- Implementation
 	new_filled_list (n: INTEGER): like Current
 			-- New list with `n' elements.
 		do
-			create Result.make_filled (n)
+			check unimplemented: False then end
 		end
 
 invariant
 	line_not_void: line /= Void
+	mdeol_not_void: model /= Void
 
 note
 	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"

--- a/object_graph/ma_reference_link.e
+++ b/object_graph/ma_reference_link.e
@@ -99,50 +99,54 @@ feature -- Element change
 feature {EG_FIGURE, EG_FIGURE_WORLD} -- Update
 
 	update
+		require else
+			model_attached : attached model
 			-- Some properties may have changed.
 		local
 			p1, p2: EV_COORDINATE
 			an_angle: DOUBLE
 			source_size: EV_RECTANGLE
-			l_model: like model
 		do
-			l_model := model
-			check attached l_model end -- FIXME: Implied by ...?
-			if not l_model.is_reflexive then
-				if attached source as l_source and then attached target as l_target then
-					p1 := line.point_array.item (0)
-					p2 := line.point_array.item (1)
+			if attached model as l_model then
+				if not l_model.is_reflexive then
+					if attached source as l_source and then attached target as l_target then
+						p1 := line.point_array.item (0)
+						p2 := line.point_array.item (1)
 
-					p1.set (l_source.port_x, l_source.port_y)
-					p2.set (l_target.port_x, l_target.port_y)
+						p1.set (l_source.port_x, l_source.port_y)
+						p2.set (l_target.port_x, l_target.port_y)
 
-					an_angle := line_angle (p1.x_precise, p1.y_precise, p2.x_precise, p2.y_precise)
-					l_source.update_edge_point (p1, an_angle)
-					an_angle := pi + an_angle
-					l_target.update_edge_point (p2, an_angle)
-				elseif attached source as l_source_2 then
-					p1 := line.point_array.item (0)
-					p1.set (l_source_2.port_x, l_source_2.port_y)
-					l_source_2.update_edge_point (p1, 0)
-				elseif attached target as l_target_2 then
-					p2 := line.point_array.item (1)
-					p2.set (l_target_2.port_x, l_target_2.port_y)
-					l_target_2.update_edge_point (p2, 0)
-				end
+						an_angle := line_angle (p1.x_precise, p1.y_precise, p2.x_precise, p2.y_precise)
+						l_source.update_edge_point (p1, an_angle)
+						an_angle := pi + an_angle
+						l_target.update_edge_point (p2, an_angle)
+					elseif attached source as l_source_2 then
+						p1 := line.point_array.item (0)
+						p1.set (l_source_2.port_x, l_source_2.port_y)
+						l_source_2.update_edge_point (p1, 0)
+					elseif attached target as l_target_2 then
+						p2 := line.point_array.item (1)
+						p2.set (l_target_2.port_x, l_target_2.port_y)
+						l_target_2.update_edge_point (p2, 0)
+					end
 
-				line.invalidate
-				line.center_invalidate
-				if is_label_shown then
-					name_label.set_point_position (line.x, line.y)
+					line.invalidate
+					line.center_invalidate
+					if is_label_shown then
+						name_label.set_point_position (line.x, line.y)
+					end
+				else
+					if attached source as l_source_3 then
+						source_size := l_source_3.size
+						reflexive.set_x_y (source_size.right + reflexive.radius1, source_size.top + source_size.height // 2)
+					end
+					if is_label_shown then
+						name_label.set_point_position (reflexive.x + reflexive.radius1, reflexive.y)
+					end
 				end
 			else
-				if attached source as l_source_3 then
-					source_size := l_source_3.size
-					reflexive.set_x_y (source_size.right + reflexive.radius1, source_size.top + source_size.height // 2)
-				end
-				if is_label_shown then
-					name_label.set_point_position (reflexive.x + reflexive.radius1, reflexive.y)
-				end
+				check attached_model : false end -- Implied by precondition model_attached
+				-- if model is not attached the precondtion is not satisfied  and we just ignore the call to update since the behaviour is undefined.
 			end
 			is_update_required := False
 		end
@@ -185,14 +189,14 @@ invariant
 	line_not_void: line /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2006, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 

--- a/object_graph/ma_reference_link.e
+++ b/object_graph/ma_reference_link.e
@@ -101,8 +101,6 @@ feature -- Element change
 feature {EG_FIGURE, EG_FIGURE_WORLD} -- Update
 
 	update
-		require else
-			model_attached : attached model
 			-- Some properties may have changed.
 		local
 			p1, p2: EV_COORDINATE

--- a/singletons/ma_icons_singleton.e
+++ b/singletons/ma_icons_singleton.e
@@ -34,12 +34,18 @@ feature {NONE} -- Implementation
 
 	pixmap_path: PATH
 			-- Path containing all of the Memory Analyzer icons
+		require else
+			attached_pixmap_path : attached internal_pixmap_path
 		local
 			l_result: like internal_pixmap_path
 		do
 			l_result := internal_pixmap_path
-			check attached l_result end -- FIXME: Implied by ...?
-			Result := l_result
+			if attached l_result as l_r then --
+				Result := l_r
+			else
+				check l_result_attached : false end --  Implied by precondition attached_pixmap_path
+				create Result.make_empty -- Since the behaviour is undefined when precondition is not satisfied we are allowed to return an empty path
+			end
 		end
 
 	internal_pixmap_path: detachable like pixmap_path
@@ -263,7 +269,7 @@ feature {NONE} -- Icons' Names
 			-- Icon names
 
 note
-	copyright:	"Copyright (c) 1984-2012, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/singletons/ma_icons_singleton.e
+++ b/singletons/ma_icons_singleton.e
@@ -34,19 +34,13 @@ feature {NONE} -- Implementation
 
 	pixmap_path: PATH
 			-- Path containing all of the Memory Analyzer icons
-		require else
-			attached_pixmap_path : attached internal_pixmap_path
-		local
-			l_result: like internal_pixmap_path
-		do
-			l_result := internal_pixmap_path
-			if attached l_result as l_r then --
-				Result := l_r
-			else
-				check l_result_attached : false end --  Implied by precondition attached_pixmap_path
-				create Result.make_empty -- Since the behaviour is undefined when precondition is not satisfied we are allowed to return an empty path
-			end
+	do
+		if attached internal_pixmap_path as l_result then
+			Result := l_result
+		else
+			create Result.make_current
 		end
+	end
 
 	internal_pixmap_path: detachable like pixmap_path
 			-- Path where have icons image.

--- a/singletons/ma_shared_pixmap_factory.e
+++ b/singletons/ma_shared_pixmap_factory.e
@@ -100,8 +100,11 @@ feature {NONE} -- Implementation
 			result_compares_objects: Result.object_comparison
 		end
 
+
+
+
 note
-	copyright:	"Copyright (c) 1984-2012, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/singletons/ma_shared_pixmap_factory.e
+++ b/singletons/ma_shared_pixmap_factory.e
@@ -82,7 +82,6 @@ feature {NONE} -- Implementation
 		deferred
 		ensure
 			result_not_void: Result /= Void
-			not_result_is_empty: not Result.is_empty
 		end
 
 	image_matrix: EV_PIXMAP

--- a/singletons/ma_singleton_factory.e
+++ b/singletons/ma_singleton_factory.e
@@ -73,11 +73,8 @@ feature  -- Singletons
 			-- MEMORY_TOOL_WINDOW instance
 		require
 			set: is_main_window_set
-		local
-			l_item: detachable MA_WINDOW
 		do
-			l_item := internal_main_window.item
-			if attached l_item as l_i then
+			if attached internal_main_window.item as l_item then
 				Result := l_item
 			else
 				check l_item_attached : false end -- Implied by precondition

--- a/singletons/ma_singleton_factory.e
+++ b/singletons/ma_singleton_factory.e
@@ -77,8 +77,12 @@ feature  -- Singletons
 			l_item: detachable MA_WINDOW
 		do
 			l_item := internal_main_window.item
-			check attached l_item end -- Implied by precondition
-			Result := l_item
+			if attached l_item as l_i then
+				Result := l_item
+			else
+				check l_item_attached : false end -- Implied by precondition
+				create Result.make ("")  -- Since the behaviour is undefined when precondition is not satisfied we are allowed to return an undefined window.
+			end
 		ensure
 			result_not_void: Result /= Void
 		end
@@ -235,14 +239,14 @@ invariant
 	internal_main_window_not_void: internal_main_window /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2008, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 end

--- a/widgets/ma_constants_imp.e
+++ b/widgets/ma_constants_imp.e
@@ -453,8 +453,12 @@ feature -- Access
 			l_item: detachable STRING
 		do
 			l_item := all_constants.item (a_name)
-			check l_item /= Void end -- Implied by precondition `has_constant'
-			Result := l_item.twin
+			if attached l_item as l_i then
+				Result := l_item.twin
+			else
+				check l_item_attached : false end -- Implied by precondition `has_constant'
+				create Result.make_empty -- Since the behaviour is undefined when precondition is not satisfied we are allowed to return an empty string
+			end
 		ensure
 			Result_not_void: Result /= Void
 		end
@@ -470,8 +474,12 @@ feature -- Access
 			l_item: detachable STRING
 		do
 			l_item := all_constants.item (a_name)
-			check l_item /= Void end -- Implied by precondition `has_constant'
-			l_string := l_item.twin
+			if attached l_item as l_i then
+				l_string := l_item.twin
+			else
+				check l_item_attached : false end -- Implied by precondition `has_constant'
+				create l_string.make_empty -- Since the behaviour is undefined when precondition is not satisfied we are allowed to return 0
+			end
 			check
 				is_integer: l_string.is_integer
 			end
@@ -580,14 +588,14 @@ invariant
 	all_constants_not_void: all_constants /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2008, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 end -- class MA_CONSTANTS_IMP

--- a/widgets/ma_filter_window.e
+++ b/widgets/ma_filter_window.e
@@ -182,7 +182,7 @@ feature {NONE} -- Implementation
 		local
 			l_last_row: detachable EV_GRID_ROW
 		do
-			add_new_row (Void)
+			add_new_row (Void) -- Construct a new row where the first item is editable.
 			l_last_row := grid.last_visible_row
 			if attached l_last_row as l_last_r then
 				if attached {EV_GRID_EDITABLE_ITEM} l_last_row.item (1) as l_item then
@@ -296,17 +296,11 @@ feature {NONE} -- Implementation
 	a_filter_data: TUPLE [class_name: STRING; selected: BOOLEAN; description: STRING]
 			-- A anchor, should not be called
 		require
-			False
-		local
-			l_result: detachable like a_filter_data
+			not_callable : False
 		do
-			check False end -- Anchor type only
-			if attached l_result as l_res then
-				Result := l_result
-			else -- Satisfy void-safe compile. Since precondition states false the behaviour is not defined if called without precondition and checks.
-				check l_result_attached : false end
-				create Result
-			end
+			check False then end
+		ensure
+			for_typing_only : False
 		end
 
 	hash_table_datas_to_arrayed_list_datas: MA_ARRAYED_LIST_STORABLE [like a_filter_data]

--- a/widgets/ma_filter_window.e
+++ b/widgets/ma_filter_window.e
@@ -184,11 +184,16 @@ feature {NONE} -- Implementation
 		do
 			add_new_row (Void)
 			l_last_row := grid.last_visible_row
-			check attached l_last_row end -- FIXME: Implied by ...?
-			if attached {EV_GRID_EDITABLE_ITEM} l_last_row.item (1) as l_item then
-				l_item.activate
+			if attached l_last_row as l_last_r then
+				if attached {EV_GRID_EDITABLE_ITEM} l_last_row.item (1) as l_item then
+					l_item.activate
+				else
+					check not_editable_item: False end
+					-- FIXMED: Implied by ...? Do we miss a precondition or invariant?
+				end
 			else
-				check not_editable_item: False end
+				check l_last_row_attached : false end
+				-- FIXME: Implied by ...? Do we miss a precondition or invariant?			
 			end
 		end
 
@@ -296,8 +301,12 @@ feature {NONE} -- Implementation
 			l_result: detachable like a_filter_data
 		do
 			check False end -- Anchor type only
-			check attached l_result end -- Satisfy void-safe compiler
-			Result := l_result
+			if attached l_result as l_res then
+				Result := l_result
+			else -- Satisfy void-safe compile. Since precondition states false the behaviour is not defined if called without precondition and checks.
+				check l_result_attached : false end
+				create Result
+			end
 		end
 
 	hash_table_datas_to_arrayed_list_datas: MA_ARRAYED_LIST_STORABLE [like a_filter_data]
@@ -354,7 +363,7 @@ invariant
 	grid_not_void: grid /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2012, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/widgets/ma_grid_check_box_item.e
+++ b/widgets/ma_grid_check_box_item.e
@@ -21,7 +21,7 @@ feature {NONE} -- Initialization
 			-- Creation method.
 		do
 			create selected_changed_actions
-			
+
 			default_create
 			expose_actions.extend (agent draw_overlay_pixmap)
 			pointer_button_press_actions.force_extend (agent handle_pointer_pressed)
@@ -108,8 +108,11 @@ feature {NONE} -- Implementation
 					a_drawable.set_foreground_color (l_row_background_color)
 				else
 					l_parent_2 := parent
-					check attached l_parent_2 end -- FIXME: Implied by ...?
-					a_drawable.set_foreground_color (l_parent_2.background_color)
+					if attached l_parent_2 as l_p then
+						a_drawable.set_foreground_color (l_p.background_color)
+					else
+						check l_parent_2_attached : false end -- FIXME: Implied by ...? -- I have tried to understand if the state of the current instance tells us that this will not happen. Next step would be to define a precondition or invariant. At least the behaviour is not worse than before this change.
+					end
 				end
 			end
 			a_drawable.fill_rectangle (0, 0, a_drawable.width, a_drawable.height)
@@ -242,14 +245,14 @@ invariant
 	selected_changed_actions_not_void: selected_changed_actions /= Void
 
 note
-	copyright:	"Copyright (c) 1984-2006, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
-			 Eiffel Software
-			 356 Storke Road, Goleta, CA 93117 USA
-			 Telephone 805-685-1006, Fax 805-685-6869
-			 Website http://www.eiffel.com
-			 Customer support http://support.eiffel.com
+			Eiffel Software
+			5949 Hollister Ave., Goleta, CA 93117 USA
+			Telephone 805-685-1006, Fax 805-685-6869
+			Website http://www.eiffel.com
+			Customer support http://support.eiffel.com
 		]"
 
 

--- a/widgets/ma_grid_check_box_item.e
+++ b/widgets/ma_grid_check_box_item.e
@@ -94,32 +94,27 @@ feature {NONE} -- Implementation
 			-- Draw the pixmap which represent whether current is selected.
 		require
 			a_drawable_not_void: a_drawable /= Void
-		local
-			l_parent_2: detachable EV_CONTAINER
 		do
-			if is_selected and attached parent as l_parent then
-				if l_parent.has_focus then
-					a_drawable.set_foreground_color (l_parent.focused_selection_color)
-				else
-					a_drawable.set_foreground_color (l_parent.non_focused_selection_color)
-				end
-			else
-				if attached row.background_color as l_row_background_color then
-					a_drawable.set_foreground_color (l_row_background_color)
-				else
-					l_parent_2 := parent
-					if attached l_parent_2 as l_p then
-						a_drawable.set_foreground_color (l_p.background_color)
+			if attached parent as l_parent then
+				if is_selected then
+					if l_parent.has_focus then
+						a_drawable.set_foreground_color (l_parent.focused_selection_color)
 					else
-						check l_parent_2_attached : false end -- FIXME: Implied by ...? -- I have tried to understand if the state of the current instance tells us that this will not happen. Next step would be to define a precondition or invariant. At least the behaviour is not worse than before this change.
+						a_drawable.set_foreground_color (l_parent.non_focused_selection_color)
+					end
+				else
+					if attached row.background_color as l_row_background_color then
+						a_drawable.set_foreground_color (l_row_background_color)
+					else
+						a_drawable.set_foreground_color (l_parent.background_color)
 					end
 				end
-			end
-			a_drawable.fill_rectangle (0, 0, a_drawable.width, a_drawable.height)
-			if internal_selected then
-				draw_selected (a_drawable)
-			else
-				draw_unselected (a_drawable)
+				a_drawable.fill_rectangle (0, 0, a_drawable.width, a_drawable.height)
+				if internal_selected then
+					draw_selected (a_drawable)
+				else
+					draw_unselected (a_drawable)
+				end
 			end
 		end
 

--- a/widgets/ma_window.e
+++ b/widgets/ma_window.e
@@ -60,8 +60,8 @@ feature {NONE} -- Initialization
 		do
 			set_main_window (Current)
 
-			attached_timer.actions.extend (agent timer_event)
-			attached_timer.set_interval (refresh_interval)
+			timer.actions.extend (agent timer_event)
+			timer.set_interval (refresh_interval)
 			main_book.drop_actions.extend (agent main_book_drop_pebble)
 			main_book.drop_actions.set_veto_pebble_function (agent main_book_dropable)
 
@@ -84,7 +84,7 @@ feature {NONE} -- Initialization
 			search_route_button.select_actions.extend (agent search_route)
 		ensure then
 			main_window_set: main_window_not_void
-			timer_action_set: attached_timer.actions.count > 0
+			timer_action_set: timer.actions.count > 0
 			notebook_drop_action_set: main_book.drop_actions.count > 0
 			update_interval_set_normal: refresh_interval = refresh_interval_normal
 			auto_refresh_button_selected: auto_refresh.is_selected
@@ -138,9 +138,9 @@ feature -- Redefine
 	destroy
 			-- Destroy window, clear singleton.
 		do
-			attached_timer.set_interval (0)
-			attached_timer.actions.wipe_out
-			timer := Void
+			timer.set_interval (0)
+			timer.actions.wipe_out
+			timer.set_interval (0)
 			main_book.drop_actions.wipe_out
 			filter_setting.drop_actions.wipe_out
 			show_actions.wipe_out
@@ -199,14 +199,14 @@ feature {NONE} -- Implementation for agents
 			-- Enable or disable auto refresh memory graph.
 		do
 			if auto_refresh.is_selected then
-				attached_timer.set_interval (refresh_interval)
+				timer.set_interval (refresh_interval)
 				auto_refresh.set_tooltip ("Auto refresh enabled")
 			else
-				attached_timer.set_interval (0)
+				timer.set_interval (0)
 				auto_refresh.set_tooltip ("Auto refresh disabled")
 			end
 		ensure then
-			timer_state_changed: old attached_timer.interval /= attached_timer.interval
+			timer_state_changed: old timer.interval /= timer.interval
 			auto_refresh_tooltip_changed: old auto_refresh.tooltip /= auto_refresh.tooltip
 		end
 
@@ -221,32 +221,32 @@ feature {NONE} -- Implementation for agents
 				analyze_object_snap.set_finding_route_to_once (False)
 			end
 		ensure then
---			timer_state_changed: old attached_timer.interval /= attached_timer.interval
+--			timer_state_changed: old timer.interval /= timer.interval
 			auto_refresh_tooltip_changed: old auto_refresh.tooltip /= auto_refresh.tooltip
 		end
 
 	auto_refresh_change_speed
 			-- Change the refresh speed.
 		do
-			if attached_timer.interval /= 0 then
+			if timer.interval /= 0 then
 				inspect refresh_interval
 					when refresh_interval_low then
 						refresh_interval := refresh_interval_normal
-						attached_timer.set_interval (refresh_interval)
+						timer.set_interval (refresh_interval)
 						refresh_speed.set_tooltip ("Refresh speed is normal")
 					when refresh_interval_normal then
 						refresh_interval := refresh_interval_hi
-						attached_timer.set_interval (refresh_interval)
+						timer.set_interval (refresh_interval)
 						refresh_speed.set_tooltip ("Refresh speed is hi")
 					when refresh_interval_hi then
 						refresh_interval := refresh_interval_low
-						attached_timer.set_interval (refresh_interval)
+						timer.set_interval (refresh_interval)
 						refresh_speed.set_tooltip ("Refresh speed is low")
 				end
 			end
 		ensure then
-			refresh_speed_toollip_changed: attached_timer.interval /= 0 implies old refresh_speed.tooltip /= refresh_speed.tooltip
-			timer_interval_changed: attached_timer.interval /= 0 implies old attached_timer.interval /= attached_timer.interval
+			refresh_speed_toollip_changed: timer.interval /= 0 implies old refresh_speed.tooltip /= refresh_speed.tooltip
+			timer_interval_changed: timer.interval /= 0 implies old timer.interval /= timer.interval
 		end
 
 	arrange_circle_clicked
@@ -436,22 +436,8 @@ feature {NONE} -- Implementation
 	analyze_route_searcher: MA_ROUTE_TO_ONCE_SEARCHER
 			-- Searcher for routes to once object.
 
-	timer: detachable EV_TIMEOUT
+	timer:  EV_TIMEOUT
 			-- The timer used for update histogram and history.
-
-	attached_timer: EV_TIMEOUT
-			-- Attached `timer'
-		require
-			set: attached timer
-		local
-			l_result: like timer
-		do
-			l_result := timer
-			check attached l_result end -- Implied by precondition
-			Result := l_result
-		ensure
-			not_void: attached Result
-		end
 
 	refresh_interval: INTEGER
 			-- The time of interval between refersh.
@@ -482,7 +468,7 @@ invariant
 	main_book_has_tab_states_compare: main_book.has (tab_states_compare)
 
 note
-	copyright:	"Copyright (c) 1984-2012, Eiffel Software and others"
+	copyright:	"Copyright (c) 1984-2014, Eiffel Software and others"
 	license:	"Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software


### PR DESCRIPTION
It requires an updated version of the graph library not yet in SVN.

In latest version of the graph library was a redesign done that makes
this library generate an error when compiling:

Error code: VDRD(2)

Type error: redeclaration has non-conforming signature.
What to do: make sure that redeclaration uses signature (number and
types of arguments and result) conforming to that of the original.

Class: MA_OBJECT_NODE
Redefined feature: model: detachable EG_NODE From: MA_OBJECT_NODE
Precursor: model: EG_LINKABLE From: EG_LINKABLE_FIGURE

My main concern is if the changes are ok from a backward compatible perspective and if they are ok for the none void safe builds. It build in none void safe mode but do we loose some controlls, like preconditions when using attached instead of /= Void.

Some diffs are large due to that I introduced new if-statements. github-diff does not seem to handle that in a good way. It looked better in SVN. Might be that I need to set something like "ignore white space changes" but I can not find that setting in github.
